### PR TITLE
Fix: zfill crc16 then update AcquirerID and Version

### DIFF
--- a/ThaiPaymentQR/KShopQR.py
+++ b/ThaiPaymentQR/KShopQR.py
@@ -14,7 +14,7 @@ class KShopQR(PromptPayQR):
         ]
         payment_innovation_data = [
             PromptPayField("00", "AppID", "A000000677010113"),
-            PromptPayField("01", "BillerID", "010753600031508"),
+            PromptPayField("01", "AcquirerID", "004"),
             PromptPayField("02", "ShopID", shopID),
             PromptPayField("04", "Ref", f"KPS{Ref}"),
         ]

--- a/ThaiPaymentQR/KShopQR_test.py
+++ b/ThaiPaymentQR/KShopQR_test.py
@@ -6,8 +6,8 @@ def constant_and_checksum_test(ksp_str: str):
     # Expected 000201 in ksp_str
     assert "000201" in ksp_str, "Prefix representation is incorrect."
 
-    # Expected 010212 in ksp_str
-    assert "010212" in ksp_str, "Payload Format Indicator representation is incorrect."
+    # Expected 010211 in ksp_str
+    assert "010211" in ksp_str, "Payload Format Indicator representation is incorrect."
 
     # Expected 0016A000000677010112 in ksp_str
     assert (
@@ -15,7 +15,9 @@ def constant_and_checksum_test(ksp_str: str):
     ), "Merchant Account Information representation is incorrect."
 
     # Expected 0115010753600031508 in ksp_str
-    assert "0115010753600031508" in ksp_str, "Merchant Category Code representation is incorrect."
+    assert (
+        "0115010753600031508" in ksp_str
+    ), "Merchant Category Code representation is incorrect."
 
     # Expected 5303764 in ksp_str
     assert "5303764" in ksp_str, "Transaction Currency representation is incorrect."
@@ -27,8 +29,11 @@ def constant_and_checksum_test(ksp_str: str):
     crc = crc_obj.calculate(ksp_str[:-4])
     crc_hex = format(crc, "X").upper()
 
+    if len(crc_hex) != 4:
+        crc_hex = crc_hex.zfill(4)
+
     # Expected CRC16 checksum in ksp_str
-    assert crc_hex in ksp_str, "CRC16 checksum representation is incorrect."
+    assert crc_hex == ksp_str[-4:], "CRC16 checksum representation is incorrect."
 
 
 def test_crc16():
@@ -56,7 +61,9 @@ def test_KShopQR():
     assert "30" in ksp.fields, "BillPayment field should be in KShopQR fields."
 
     # Expected field 30 data
-    assert str(ksp.fields["30"]) in ksp_str, "BillPayment field data should be in KShopQR string."
+    assert (
+        str(ksp.fields["30"]) in ksp_str
+    ), "BillPayment field data should be in KShopQR string."
 
     # Expected field 31
     assert "31" in ksp.fields, "PaymentInnovation field should be in KShopQR fields."
@@ -77,7 +84,7 @@ def test_KShopQR():
 
     # Expected data (without 8 last characters) in ksp_str
     assert len(ksp_str[:-8]) == len(
-        "00020101021230750016A000000677010112011501075360003150802150140000008209100313KPSTESTPYTHON31750016A000000677010113011501075360003150802150140000008209100413KPSTESTPYTHON5303764540514.535802TH"
+        "00020101021130750016A000000677010112011501075360003150802150140000008209100313KPSTESTPYTHON31630016A000000677010113010300402150140000008209100413KPSTESTPYTHON5303764540514.535802TH"
     ), "Data length is incorrect."
 
 
@@ -103,8 +110,18 @@ def test_KShopQR_2():
 
     # Expected data (without 8 last characters) in ksp_str
     assert len(ksp_str[:-8]) == len(
-        "00020101021230710016A000000677010112011501075360003150802150140000008209100309KPS31212131710016A000000677010113011501075360003150802150140000008209100409KPS312121530376454071212.005802TH"
+        "00020101021130710016A000000677010112011501075360003150802150140000008209100309KPS31212131590016A000000677010113010300402150140000008209100409KPS312121530376454071212.005802TH"
     ), "Data length is incorrect."
+
+
+def test_KShopQR_CRC():
+    from ThaiPaymentQR import KShopQR
+
+    ksp = KShopQR("014000000820910", "Supatipanno")
+    ksp.setAmount(40010.00)
+    ksp_str = str(ksp)
+    assert ksp_str[-4] == "0", "CRC16 checksum for this test should be zero-leading."
+    constant_and_checksum_test(ksp_str)
 
 
 if __name__ == "__main__":

--- a/ThaiPaymentQR/KShopQR_test.py
+++ b/ThaiPaymentQR/KShopQR_test.py
@@ -15,9 +15,7 @@ def constant_and_checksum_test(ksp_str: str):
     ), "Merchant Account Information representation is incorrect."
 
     # Expected 0115010753600031508 in ksp_str
-    assert (
-        "0115010753600031508" in ksp_str
-    ), "Merchant Category Code representation is incorrect."
+    assert "0115010753600031508" in ksp_str, "Merchant Category Code representation is incorrect."
 
     # Expected 5303764 in ksp_str
     assert "5303764" in ksp_str, "Transaction Currency representation is incorrect."
@@ -61,9 +59,7 @@ def test_KShopQR():
     assert "30" in ksp.fields, "BillPayment field should be in KShopQR fields."
 
     # Expected field 30 data
-    assert (
-        str(ksp.fields["30"]) in ksp_str
-    ), "BillPayment field data should be in KShopQR string."
+    assert str(ksp.fields["30"]) in ksp_str, "BillPayment field data should be in KShopQR string."
 
     # Expected field 31
     assert "31" in ksp.fields, "PaymentInnovation field should be in KShopQR fields."

--- a/ThaiPaymentQR/MaeManeeQR_test.py
+++ b/ThaiPaymentQR/MaeManeeQR_test.py
@@ -15,9 +15,7 @@ def constant_and_checksum_test(mmn_str: str):
     ), "Merchant Account Information representation is incorrect."
 
     # Expected 0115010753600010286 in mmn_str
-    assert (
-        "0115010753600010286" in mmn_str
-    ), "Merchant Category Code representation is incorrect."
+    assert "0115010753600010286" in mmn_str, "Merchant Category Code representation is incorrect."
 
     # Expected 622007160000000000085234 in mmn_str
     assert (
@@ -94,9 +92,7 @@ def test_MaeManeeQR_2():
     ), "BillPayment field data should be in MaeManeeQR string."
 
     # NOT Expected field 31
-    assert (
-        "31" not in mmn.fields
-    ), "PaymentInnovation field should not be in MaeManeeQR fields."
+    assert "31" not in mmn.fields, "PaymentInnovation field should not be in MaeManeeQR fields."
 
     # Expected 0215014000000820910 in mmn_str
     assert "0215014000000820910" in mmn_str, "ShopID representation is incorrect."
@@ -111,6 +107,7 @@ def test_MaeManeeQR_2():
     assert len(mmn_str[:-8]) == len(
         "00020101021130680016A000000677010112011501075360001028602150140000008209100306312121530376454071212.005802TH622007160000000000085234"
     ), "Data length is incorrect."
+
 
 def test_KShopQR_CRC():
     from ThaiPaymentQR import MaeManeeQR

--- a/ThaiPaymentQR/MaeManeeQR_test.py
+++ b/ThaiPaymentQR/MaeManeeQR_test.py
@@ -6,8 +6,8 @@ def constant_and_checksum_test(mmn_str: str):
     # Expected 000201 in mmn_str
     assert "000201" in mmn_str, "Prefix representation is incorrect."
 
-    # Expected 010212 in mmn_str
-    assert "010212" in mmn_str, "Payload Format Indicator representation is incorrect."
+    # Expected 010211 in mmn_str
+    assert "010211" in mmn_str, "Payload Format Indicator representation is incorrect."
 
     # Expected 0016A000000677010112 in mmn_str
     assert (
@@ -15,7 +15,9 @@ def constant_and_checksum_test(mmn_str: str):
     ), "Merchant Account Information representation is incorrect."
 
     # Expected 0115010753600010286 in mmn_str
-    assert "0115010753600010286" in mmn_str, "Merchant Category Code representation is incorrect."
+    assert (
+        "0115010753600010286" in mmn_str
+    ), "Merchant Category Code representation is incorrect."
 
     # Expected 622007160000000000085234 in mmn_str
     assert (
@@ -68,11 +70,11 @@ def test_maemaneeqr():
 
     # Expected data (without 8 last characters) in mmn_str
     assert len(mmn_str[:-8]) == len(
-        "00020101021230720016A000000677010112011501075360001028602150140000008209100310TESTPYTHON5303764540514.535802TH622007160000000000085234"
+        "00020101021130720016A000000677010112011501075360001028602150140000008209100310TESTPYTHON5303764540514.535802TH622007160000000000085234"
     ), "Data length is incorrect."
 
 
-def test_maemaneeqr_2():
+def test_MaeManeeQR_2():
     from ThaiPaymentQR import MaeManeeQR
 
     mmn = MaeManeeQR("014000000820910", "312121")
@@ -92,7 +94,9 @@ def test_maemaneeqr_2():
     ), "BillPayment field data should be in MaeManeeQR string."
 
     # NOT Expected field 31
-    assert "31" not in mmn.fields, "PaymentInnovation field should not be in MaeManeeQR fields."
+    assert (
+        "31" not in mmn.fields
+    ), "PaymentInnovation field should not be in MaeManeeQR fields."
 
     # Expected 0215014000000820910 in mmn_str
     assert "0215014000000820910" in mmn_str, "ShopID representation is incorrect."
@@ -105,8 +109,17 @@ def test_maemaneeqr_2():
 
     # Expected data (without 8 last characters) in mmn_str
     assert len(mmn_str[:-8]) == len(
-        "00020101021230680016A000000677010112011501075360001028602150140000008209100306312121530376454071212.005802TH622007160000000000085234"
+        "00020101021130680016A000000677010112011501075360001028602150140000008209100306312121530376454071212.005802TH622007160000000000085234"
     ), "Data length is incorrect."
+
+def test_KShopQR_CRC():
+    from ThaiPaymentQR import MaeManeeQR
+
+    ksp = MaeManeeQR("014000000820910", "Supatipanno")
+    ksp.setAmount(40007.00)
+    ksp_str = str(ksp)
+    assert ksp_str[-4] == "0", "CRC16 checksum for this test should be zero-leading."
+    constant_and_checksum_test(ksp_str)
 
 
 if __name__ == "__main__":

--- a/ThaiPaymentQR/PromptPayQR.py
+++ b/ThaiPaymentQR/PromptPayQR.py
@@ -8,7 +8,7 @@ class PromptPayQR:
     def __init__(self):
         self.crc_obj = CRCCCITT("FFFF")
         self.addField("version", "01", "00")
-        self.addField("onetime", "12", "01")
+        self.addField("onetime", "11", "01")
         self.addField("currency", "764", "53")
         self.addField("country", "TH", "58")
 
@@ -29,7 +29,7 @@ class PromptPayQR:
 
         crc = self.crc_obj.calculate(outStr + "6304")
         crchex = hex(crc)[2:].upper()
-        crcField = PromptPayField("63", "crc16", crchex)
+        crcField = PromptPayField("63", "crc16", crchex.zfill(4))
         outStr += str(crcField)
 
         return outStr


### PR DESCRIPTION
# Pull Request Template

## Description

- Zfill(4) CRC16 in case that the hex value have zero leading.
- Downgrade Version of PromptPayQR to older one to support old version.
- KShopQR BillerID changed to AcquirerID

## Type of Change

Please delete options that are not relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

None

## Additional Context

None
